### PR TITLE
[rando] Refactor randomizer code

### DIFF
--- a/neutopia/src/chest.rs
+++ b/neutopia/src/chest.rs
@@ -4,7 +4,7 @@ use byteorder::WriteBytesExt;
 use failure::{format_err, Error};
 use nom::{multi::many_m_n, number::complete::le_u8, IResult};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Chest {
     pub item_id: u8,
     pub arg: u8,

--- a/neutopia/src/object.rs
+++ b/neutopia/src/object.rs
@@ -10,7 +10,7 @@ use nom::{
     IResult,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ObjectInfo {
     pub x: u8,
     pub y: u8,
@@ -23,7 +23,7 @@ impl fmt::Display for ObjectInfo {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TableEntry {
     Object(ObjectInfo),
     OpenDoor(u8),

--- a/neutopia/src/object.rs
+++ b/neutopia/src/object.rs
@@ -79,7 +79,31 @@ impl TableEntry {
         }
         Ok(())
     }
+
+    pub fn chest_id(&self) -> Option<u8> {
+        if let Self::Object(o) = self {
+            if 0x4c <= o.id && o.id <= (0x4c + 8) {
+                return Some(o.id - 0x4c);
+            }
+        }
+        None
+    }
+
+    pub fn is_conditional(&self) -> bool {
+        match self {
+            Self::Unknown0b(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn loc(&self) -> Option<(u8, u8)> {
+        match self {
+            Self::Object(o) => Some((o.x, o.y)),
+            _ => None,
+        }
+    }
 }
+
 impl fmt::Display for TableEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/rando/src/main.rs
+++ b/rando/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{prelude::*, Cursor, SeekFrom};
 use std::path::PathBuf;
@@ -9,7 +10,7 @@ use rand_core::SeedableRng;
 use rand_pcg::Pcg32;
 use structopt::StructOpt;
 
-use neutopia::{object, object::parse_object_table, Chest, Neutopia};
+use neutopia::{self, object, object::parse_object_table, Neutopia};
 #[derive(StructOpt, Debug)]
 #[structopt(name = "basic")]
 struct Opt {
@@ -21,96 +22,315 @@ struct Opt {
 
     #[structopt(long)]
     seed: Option<String>,
+
+    #[structopt(long)]
+    global: bool,
 }
 
-// Returns a list of chests that are allowed to be randomized (so no crypt keys, crystal balls or medallions are returned here)
-// All these chests are piled on one big heap, randomized and passed into write_new_chests_for_area.
-fn get_randomizable_chests_for_area(n: &Neutopia, area_index: usize) -> Vec<Chest> {
-    let room_info_table = &n.room_info_tables[area_index];
-    let chest_table = &n.chest_tables[&n.chest_table_pointers[area_index]];
+#[derive(Clone, Debug)]
+struct Room {
+    pub warps: Vec<u8>,
+    pub enemies: Vec<u8>,
+    pub objects: Vec<object::TableEntry>,
+}
 
-    // find all chests that are OK to randomize
-    let mut chests = Vec::new();
-    for room_id in 0u8..0x40 {
-        let room = &room_info_table[&room_id];
-        let object_table = parse_object_table(&room.object_table).unwrap_or_default();
-        for entry in &object_table {
-            if let object::TableEntry::Object(info) = entry {
-                if 0x4c <= info.id && info.id <= (0x4c + 8) {
-                    let id = info.id - 0x4c;
-                    let chest = &chest_table[id as usize];
+#[derive(Clone, Debug)]
+struct Area {
+    pub rooms: Vec<Room>,
+    pub chest_table: Vec<neutopia::Chest>,
+}
 
-                    // Ensure it is not the medallion, crypt key or crystal ball.
-                    if chest.item_id < 0x10 || chest.item_id >= (0x12 + 8) {
-                        chests.push(chest.clone());
+#[derive(Clone, Debug)]
+struct Chest {
+    info: neutopia::Chest,
+    area: u8,
+    room: u8,
+    id: usize,
+}
+#[derive(Clone, Debug)]
+struct Conditional {
+    data: Vec<object::TableEntry>,
+}
+
+struct Randomizer {
+    pub areas: Vec<Area>,
+    pub conditionals: HashMap<neutopia::Chest, Conditional>,
+    pub rom_data: Vec<u8>,
+    n: Neutopia,
+}
+
+impl Randomizer {
+    pub fn new(data: &[u8]) -> Result<Randomizer, Error> {
+        let mut rando = Randomizer {
+            n: Neutopia::new(data)?,
+            areas: Vec::new(),
+            conditionals: HashMap::new(),
+            rom_data: Vec::from(data),
+        };
+
+        for area_idx in 0..=0xf {
+            rando.import_area(area_idx)?;
+        }
+
+        Ok(rando)
+    }
+
+    fn import_area(&mut self, area_idx: usize) -> Result<(), Error> {
+        let room_info_table = &self.n.room_info_tables[area_idx];
+        let chest_table = &self.n.chest_tables[&self.n.chest_table_pointers[area_idx]];
+
+        let mut rooms = Vec::new();
+
+        for room_idx in 0u8..0x40 {
+            let room = &room_info_table[&room_idx];
+            let mut object_table = parse_object_table(&room.object_table)?;
+
+            // First scan for conditionals, record them, then remove them from the
+            // table entries.
+            if object_table.len() > 2 {
+                for i in 0..(object_table.len() - 2) {
+                    if let Some(id) = object_table[i].chest_id() {
+                        let chest = &chest_table[id as usize];
+                        let next = object_table[i + 1].clone();
+                        let next_next = object_table[i + 2].clone();
+
+                        if next.is_conditional() {
+                            object_table.remove(i + 1);
+                            object_table.remove(i + 1);
+                            self.conditionals.insert(
+                                chest.clone(),
+                                Conditional {
+                                    data: vec![next, next_next],
+                                },
+                            );
+                            break;
+                        }
                     }
                 }
             }
+
+            rooms.push(Room {
+                warps: room.warp_table.clone(),
+                enemies: room.enemy_table.clone(),
+                objects: object_table,
+            });
         }
+
+        self.areas.push(Area {
+            rooms,
+            chest_table: chest_table.clone(),
+        });
+        Ok(())
     }
 
-    chests
-}
+    fn filter_chests(&self, filter: impl Fn(&Chest) -> bool) -> Vec<Chest> {
+        let mut chests = Vec::new();
 
-// Takes a list of all (remaining) randomizable chests, pops them off one by one for chests it can randomize into
-fn write_new_chests_for_area(
-    n: &Neutopia,
-    area_index: usize,
-    data: &mut [u8],
-    randomizable_chests: &mut Vec<Chest>,
-) -> Result<(), Error> {
-    let room_info_table = &n.room_info_tables[area_index];
-    let chest_table = &n.chest_tables[&n.chest_table_pointers[area_index]];
-
-    // find all chests that are OK to randomize and replace them with the top chest in randomizable_chests
-    let mut chest_ids = Vec::new();
-    let mut chest_contents = Vec::new();
-    for room_id in 0u8..0x40 {
-        let room = &room_info_table[&room_id];
-        let object_table = parse_object_table(&room.object_table)?;
-        for entry in &object_table {
-            if let object::TableEntry::Object(info) = entry {
-                if 0x4c <= info.id && info.id <= (0x4c + 8) {
-                    let id = info.id - 0x4c;
-                    let chest = &chest_table[id as usize];
-
-                    // Ensure it is not the medallion, crypt key or crystal ball.
-                    if chest.item_id < 0x10 || chest.item_id >= (0x12 + 8) {
-                        if let Some(randomizable_chest) = randomizable_chests.pop() {
-                            chest_ids.push(id);
-                            chest_contents.push(randomizable_chest);
-                        } else {
-                            return Err(format_err!("Terrible error, ran out of chests! T_T"));
+        for (area_idx, area) in self.areas.iter().enumerate() {
+            for (room_idx, room) in area.rooms.iter().enumerate() {
+                for entry in &room.objects {
+                    if let Some(id) = entry.chest_id() {
+                        let chest = Chest {
+                            info: area.chest_table[id as usize].clone(),
+                            area: area_idx as u8,
+                            room: room_idx as u8,
+                            id: id as usize,
+                        };
+                        if filter(&chest) {
+                            chests.push(chest);
                         }
                     }
                 }
             }
         }
+
+        chests
     }
 
-    // Patch up a new chest table
-    let mut new_chest_table = chest_table.clone();
-    for (chest_id, contents) in chest_ids.iter().zip(chest_contents.iter()) {
-        new_chest_table[*chest_id as usize] = contents.clone();
+    fn update_chests(&mut self, chests: &[Chest]) -> Result<(), Error> {
+        for chest in chests {
+            let entry = self.areas[chest.area as usize]
+                .chest_table
+                .get_mut(chest.id)
+                .ok_or_else(|| format_err!("incoherent chest id {:02x}", chest.id))?;
+
+            *entry = chest.info.clone();
+        }
+
+        Ok(())
     }
 
-    let mut c = Cursor::new(data);
+    fn write_area(&self, area_idx: usize, rom_writer: &mut Cursor<Vec<u8>>) -> Result<u32, Error> {
+        let area = &self.areas[area_idx];
+        let cur_offset = rom_writer.position();
 
-    // Write the new table to some unused memory.
-    let offset = 0x4fe00 + (0x20 * area_index as u64);
-    c.seek(SeekFrom::Start(offset))?;
-    for chest in &new_chest_table {
-        chest.write(&mut c)?;
+        let mut room_ptrs = Cursor::new(Vec::new());
+        let room_ptrs_offset = cur_offset;
+        let room_data_offset = cur_offset + 0x40 * 3;
+        rom_writer.seek(SeekFrom::Start(room_data_offset as u64))?;
+        for room_idx in 0..0x40 {
+            let room = &area.rooms[room_idx];
+
+            let room_offset = rom_writer.position();
+            room_ptrs.write_all(&neutopia::util::rom_offset_to_pointer(room_offset as u32))?;
+
+            // Add conditionals back to object_table.
+            let mut object_table = room.objects.clone();
+            for i in 0..object_table.len() {
+                if let Some(id) = object_table[i].chest_id() {
+                    let chest = &area.chest_table[id as usize];
+                    let loc = match object_table[i].loc() {
+                        Some(loc) => loc,
+                        _ => continue,
+                    };
+                    if let Some(cond) = self.conditionals.get(&chest) {
+                        for j in 0..cond.data.len() {
+                            let mut entry = cond.data[j].clone();
+                            if let object::TableEntry::Object(ref mut o) = entry {
+                                // Patch second objects location to match
+                                o.x = loc.0;
+                                o.y = loc.1;
+                            }
+                            object_table.insert(i + j + 1, entry);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // Skip over the warp, enemy, and object table pointers for now.
+            rom_writer.seek(SeekFrom::Current(3 * 3))?;
+
+            let warp_table_ptr = rom_writer.position() as u32;
+            rom_writer.write_all(&room.warps)?;
+
+            let enemy_table_ptr = rom_writer.position() as u32;
+            rom_writer.write_all(&room.enemies)?;
+            rom_writer.write_all(&[0xff])?;
+
+            let object_table_ptr = rom_writer.position() as u32;
+            for o in &object_table {
+                o.write(rom_writer)?;
+            }
+            rom_writer.write_all(&[0xff])?;
+
+            // Rewind and write table pointers.
+            let room_end_pos = rom_writer.position();
+            rom_writer.seek(SeekFrom::Start(room_offset))?;
+            rom_writer.write_all(&neutopia::util::rom_offset_to_pointer(warp_table_ptr))?;
+            rom_writer.write_all(&neutopia::util::rom_offset_to_pointer(enemy_table_ptr))?;
+            rom_writer.write_all(&neutopia::util::rom_offset_to_pointer(object_table_ptr))?;
+            rom_writer.seek(SeekFrom::Start(room_end_pos))?;
+        }
+
+        // Record the end of the area.
+        let next_offset = rom_writer.position() as u32;
+
+        // Rewind and write out the pointer to the room data.
+        rom_writer.seek(SeekFrom::Start(room_ptrs_offset as u64))?;
+        rom_writer.write_all(room_ptrs.get_ref())?;
+
+        // And finally write out new area pointer.
+        rom_writer.seek(SeekFrom::Start(
+            neutopia::rommap::AREA_TABLE as u64 + area_idx as u64 * 3,
+        ))?;
+        rom_writer.write_all(&neutopia::util::rom_offset_to_pointer(
+            room_ptrs_offset as u32,
+        ))?;
+
+        Ok(next_offset)
     }
 
-    // Update the area's chest table pointer.
-    c.seek(SeekFrom::Start(
-        neutopia::rommap::CHEST_TABLE as u64 + 3 * area_index as u64,
-    ))?;
-    let ptr = neutopia::util::rom_offset_to_pointer(offset as u32);
-    c.write_all(&ptr)?;
+    fn write(&self) -> Result<Vec<u8>, Error> {
+        let mut rom_writer = Cursor::new(self.rom_data.clone());
 
-    Ok(())
+        // For now we're only doing crypts
+        let area_range = 4..=0xb;
+
+        // First patch chest tables
+        for area_idx in area_range.clone() {
+            let area = &self.areas[area_idx];
+            // Relocate and write the new chest table.
+            let offset = 0x4fe00 + (0x20 * area_idx as u64);
+            rom_writer.seek(SeekFrom::Start(offset))?;
+            for chest in &area.chest_table {
+                chest.write(&mut rom_writer)?;
+            }
+
+            // Update the area's chest table pointer.
+            rom_writer.seek(SeekFrom::Start(
+                neutopia::rommap::CHEST_TABLE as u64 + 3 * area_idx as u64,
+            ))?;
+            let ptr = neutopia::util::rom_offset_to_pointer(offset as u32);
+            rom_writer.write_all(&ptr)?;
+        }
+
+        // Write out area data
+
+        // Beginning or area data starts where Area 4's data starts.
+        let mut cur_offset = self.n.area_pointers[4];
+        for area_idx in area_range {
+            rom_writer.seek(SeekFrom::Start(cur_offset as u64))?;
+            cur_offset = self.write_area(area_idx, &mut rom_writer)?
+        }
+
+        Ok(rom_writer.into_inner())
+    }
+}
+
+// Shuffle all items within each crypt.  Does not touch overworld items.
+fn crypt_rando(rng: &mut impl Rng, rom_data: &[u8]) -> Result<Vec<u8>, Error> {
+    let mut rando = Randomizer::new(rom_data)?;
+
+    for area_idx in 0x4..=0xb {
+        // Find all the chest we want to randomize.
+        let mut chests = rando.filter_chests(|chest| {
+            // Chest is in current area
+            (chest.area == area_idx)
+                // Chest does not contain medallion
+                && (chest.info.item_id < 0x12 || chest.info.item_id >= (0x12 + 8))
+        });
+
+        // Shuffle the chests.
+        let mut randomized_chests: Vec<neutopia::Chest> =
+            chests.iter().map(|chest| chest.info.clone()).collect();
+        randomized_chests.shuffle(rng);
+
+        // Update the chests' info
+        for (i, chest) in chests.iter_mut().enumerate() {
+            chest.info = randomized_chests[i].clone();
+        }
+
+        rando.update_chests(&chests)?;
+    }
+
+    rando.write()
+}
+
+// Shuffle all items across crypts and overworld.  Does not contain logic
+// to make sure seed is completable.
+fn global_rando(rng: &mut impl Rng, rom_data: &[u8]) -> Result<Vec<u8>, Error> {
+    let mut rando = Randomizer::new(rom_data)?;
+
+    let mut chests = rando.filter_chests(|chest| {
+        // Chest is in current area
+        (chest.area < 0x10)
+                // Chest does not contain medallion, crystal ball, or key
+                && (chest.info.item_id < 0x10 || chest.info.item_id >= (0x12 + 8))
+    });
+
+    // Shuffle the chests.
+    let mut randomized_chests: Vec<neutopia::Chest> =
+        chests.iter().map(|chest| chest.info.clone()).collect();
+    randomized_chests.shuffle(rng);
+
+    // Update the chests' info
+    for (i, chest) in chests.iter_mut().enumerate() {
+        chest.info = randomized_chests[i].clone();
+    }
+
+    rando.update_chests(&chests)?;
+    rando.write()
 }
 
 fn main() -> Result<(), Error> {
@@ -129,29 +349,19 @@ fn main() -> Result<(), Error> {
     let mut buffer = Vec::new();
     // read the whole file
     f.read_to_end(&mut buffer)?;
+    // drop mutability of buffer
+    let buffer = buffer;
 
-    let n = Neutopia::new(&buffer)?;
-
-    // get all chests that are allowed to be randomized from the areas and put them on one big heap
-    let mut randomizable_chests = Vec::new();
-    for i in 0..=0xf {
-        let mut chests = get_randomizable_chests_for_area(&n, i);
-        randomizable_chests.append(&mut chests);
-    }
-
-    // shuffle!
-    randomizable_chests.shuffle(&mut rng);
-
-    // Have each area pick chests from the heap one by one and pass the remaining to the next area
-    for i in 0..=0xf {
-        write_new_chests_for_area(&n, i, &mut buffer, &mut randomizable_chests)?;
-    }
-
+    let new_data = if opt.global {
+        global_rando(&mut rng, &buffer)?
+    } else {
+        crypt_rando(&mut rng, &buffer)?
+    };
     let filename = &opt
         .out
         .unwrap_or_else(|| PathBuf::from(format!("neutopia-randomizer-{:#}.pce", radix_36(seed))));
     let mut f = File::create(filename)?;
-    f.write_all(&buffer)?;
+    f.write_all(&new_data)?;
 
     println!("wrote {}", filename.display());
     Ok(())


### PR DESCRIPTION
The main theory behind the refactor is to parse all the data tables
at the beginning of the randomization, keeping a single source of
truth for this data.  The randomizer then manipulates the parsed
data to shuffle the seed.  At the end the parsed data is
re-encoded and written back out to the ROM.

This allows us to more easily patch conditional expressions `0x0b`
which this patch also implements.