### PR TITLE
[build] Switch to checkout@v1 for github workflows.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: cargo fmt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
v2 looks to have a bug where sometimes picking up the wrong commit.
https://github.com/actions/checkout/issues/237