### PR TITLE
[neutopia][rando][neutil] Rename `Neutopia` to `NeutopiaRom`

### DIFF
--- a/neutil/src/doc.rs
+++ b/neutil/src/doc.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use failure::Error;
 use structopt::StructOpt;
 
-use neutopia::{object::parse_object_table, Neutopia};
+use neutopia::{object::parse_object_table, NeutopiaRom};
 
 #[derive(StructOpt, Debug)]
 pub(crate) struct DocOpt {
@@ -28,7 +28,7 @@ fn write_byte_array(f: &mut File, data: &[u8]) -> Result<(), Error> {
     Ok(())
 }
 
-fn write_area_markdown(opt: &DocOpt, n: &Neutopia, area_index: usize) -> Result<(), Error> {
+fn write_area_markdown(opt: &DocOpt, n: &NeutopiaRom, area_index: usize) -> Result<(), Error> {
     let mut path: PathBuf = opt.outdir.clone();
     path.push(format!("area_{:02x}.md", area_index));
     let mut f = File::create(path)?;
@@ -148,7 +148,7 @@ pub(crate) fn command(opt: &DocOpt) -> Result<(), Error> {
     // read the whole file
     f.read_to_end(&mut buffer)?;
 
-    let n = Neutopia::new(&buffer)?;
+    let n = NeutopiaRom::new(&buffer)?;
 
     for area_index in 0..n.area_pointers.len() {
         write_area_markdown(opt, &n, area_index)?;

--- a/neutopia/src/lib.rs
+++ b/neutopia/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Room {
     pub object_table: Vec<u8>,
 }
 
-pub struct Neutopia {
+pub struct NeutopiaRom {
     pub area_pointers: Vec<u32>,
     pub room_order_pointers: Vec<u32>,
     pub chest_table_pointers: Vec<u32>,
@@ -35,8 +35,8 @@ pub struct Neutopia {
     pub chest_tables: HashMap<u32, Vec<Chest>>,
 }
 
-impl Neutopia {
-    pub fn new(data: &[u8]) -> Result<Neutopia, Error> {
+impl NeutopiaRom {
+    pub fn new(data: &[u8]) -> Result<NeutopiaRom, Error> {
         let area_pointers =
             util::decode_pointer_table(&data[rommap::AREA_TABLE..], rommap::AREA_TABLE_COUNT)?;
         let room_order_pointers = util::decode_pointer_table(
@@ -111,7 +111,7 @@ impl Neutopia {
             chest_tables.insert(*chest_table_ptr, table);
         }
 
-        Ok(Neutopia {
+        Ok(NeutopiaRom {
             area_pointers,
             room_order_pointers,
             chest_table_pointers,

--- a/rando/src/main.rs
+++ b/rando/src/main.rs
@@ -11,7 +11,7 @@ use rand_core::SeedableRng;
 use rand_pcg::Pcg32;
 use structopt::{clap::arg_enum, StructOpt};
 
-use neutopia::{self, object, object::parse_object_table, verify::Region, Neutopia};
+use neutopia::{self, object, object::parse_object_table, verify::Region, NeutopiaRom};
 
 mod patches;
 
@@ -69,13 +69,13 @@ struct Randomizer {
     pub areas: Vec<Area>,
     pub conditionals: HashMap<neutopia::Chest, Conditional>,
     pub rom_data: Vec<u8>,
-    n: Neutopia,
+    n: NeutopiaRom,
 }
 
 impl Randomizer {
     pub fn new(data: &[u8]) -> Result<Randomizer, Error> {
         let mut rando = Randomizer {
-            n: Neutopia::new(data)?,
+            n: NeutopiaRom::new(data)?,
             areas: Vec::new(),
             conditionals: HashMap::new(),
             rom_data: Vec::from(data),


### PR DESCRIPTION
This is in preparation for moving the `Randomizer` struct into
the base neutopia crate.