### PR TITLE
[rando] Separate rando into a lib and cli.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "neutil",
     "neutopia",
     "rando",
+    "rando-cli",
 ]

--- a/rando-cli/Cargo.toml
+++ b/rando-cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rando-cli"
+version = "0.1.0"
+authors = ["Erik Gilling <konkers@konkers.net>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+failure = "0.1.8"
+rando = { path = "../rando" }
+structopt = "0.3.15"

--- a/rando-cli/src/main.rs
+++ b/rando-cli/src/main.rs
@@ -1,0 +1,50 @@
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+use failure::Error;
+use structopt::StructOpt;
+
+use rando::RandoType;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "basic")]
+struct Opt {
+    #[structopt(long, parse(from_os_str), default_value = "Neutopia (USA).pce")]
+    rom: PathBuf,
+
+    #[structopt(long, parse(from_os_str))]
+    out: Option<PathBuf>,
+
+    #[structopt(long)]
+    seed: Option<String>,
+
+    #[structopt(long = "type", default_value = "local")]
+    ty: RandoType,
+}
+
+fn main() -> Result<(), Error> {
+    let opt = Opt::from_args();
+
+    let mut f = File::open(&opt.rom)?;
+    let mut buffer = Vec::new();
+    f.read_to_end(&mut buffer)?;
+
+    let config = rando::Config {
+        seed: opt.seed,
+        ty: opt.ty,
+    };
+
+    let r = rando::randomize(&config, &buffer)?;
+
+    let filename = &opt
+        .out
+        .unwrap_or_else(|| PathBuf::from(format!("neutopia-randomizer-{}.pce", r.seed)));
+
+    let mut f = File::create(filename)?;
+    f.write_all(&r.data)?;
+
+    println!("wrote {}", filename.display());
+
+    Ok(())
+}

--- a/rando/Cargo.toml
+++ b/rando/Cargo.toml
@@ -17,7 +17,6 @@ radix_fmt = "1.0.0"
 rand = "0.7.3"
 rand_core = "0.5.1"
 rand_pcg = "0.2.1"
-structopt = "0.3.15"
 
 [build-dependencies]
 asm_build = { path = "../build/asm_build" }


### PR DESCRIPTION
This has two benefits:

1. Will allow other frontends to the rando like the web/wasm one.
2. Will allow neutil to share data types with the rando for generating
   tables.