### PR TITLE
[neutopia] Add Ord to Chest object.

### DIFF
--- a/neutopia/src/rom/chest.rs
+++ b/neutopia/src/rom/chest.rs
@@ -4,7 +4,7 @@ use byteorder::WriteBytesExt;
 use failure::{format_err, Error};
 use nom::{multi::many_m_n, number::complete::le_u8, IResult};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Chest {
     pub item_id: u8,
     pub arg: u8,


### PR DESCRIPTION
This allows Chests to be held in BTreeSets as well as the keys
for BTreeMaps